### PR TITLE
Codecov token is only set as an environment variable

### DIFF
--- a/src/PublishCodeCovCoverageTask/__tests__/index.test.ts
+++ b/src/PublishCodeCovCoverageTask/__tests__/index.test.ts
@@ -119,7 +119,7 @@ describe('PublishCodeCovCoverage', () => {
   test('run function should handle missing token', async () => {
     // Mock CODECOV_TOKEN as undefined
     (tl.getVariable as jest.Mock).mockReturnValueOnce(undefined);
-    delete process.env.CODECOV_TOKEN;
+    process.env.CODECOV_TOKEN = undefined;
 
     await run();
 
@@ -545,7 +545,7 @@ describe('PublishCodeCovCoverage', () => {
     });
 
     // Clear environment variable to ensure it gets set by the task
-    delete process.env.CODECOV_TOKEN;
+    process.env.CODECOV_TOKEN = undefined;
 
     await run();
 
@@ -580,7 +580,7 @@ describe('PublishCodeCovCoverage', () => {
     });
 
     // Clear environment variable to ensure it gets set by the task
-    delete process.env.CODECOV_TOKEN;
+    process.env.CODECOV_TOKEN = undefined;
 
     await run();
 

--- a/src/PublishCodeCovCoverageTask/index.ts
+++ b/src/PublishCodeCovCoverageTask/index.ts
@@ -26,7 +26,7 @@ export async function run(): Promise<void> {
         if (codecovToken) {
             process.env.CODECOV_TOKEN = codecovToken;
 
-            console.log('Environment variable CODECOV_TOKEN set from task input');
+            console.log('Environment variable CODECOV_TOKEN has been set');
         }
 
         console.log('Uploading code coverage to Codecov.io');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security by ensuring the Codecov token is only set as an environment variable and never exposed in command-line arguments during coverage uploads.

- **Tests**
  - Added new tests to verify secure handling of the Codecov token from both task input and pipeline variables, ensuring it is not leaked via command-line arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->